### PR TITLE
Adding support for multiple repos to be submitted

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 bin/*
 drone-trigger
+
+.idea/
+.vscode/

--- a/util.go
+++ b/util.go
@@ -12,8 +12,8 @@ import (
 
 // findBuild requests an array of previous repo builds from drone API and finds
 // the one that matches given filters
-func findBuild(c drone.Client, ctx *cli.Context) (*model.Build, error) {
-	user, repo, err := parseRepo(ctx.String("repo"))
+func findBuild(c drone.Client, ctx *cli.Context, thisRepo string) (*model.Build, error) {
+	user, repo, err := parseRepo(thisRepo)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This is addressing one of the gaps I found between this repo and the [drone-downstream](https://github.com/drone-plugins/drone-downstream) plugin. My use case requires triggering different repositories (in parallel, ideally), and this adds support for that. Admittedly, it's a flag change and a loop, and the first PR I've submitted to a Golang open source project, so feedback is appreciated. 

I tested it with a single repo or multiple, and it worked a treat. It should be backwards compatible just fine - a single `--repo` flag operates as before, but now you can pass multiple. 